### PR TITLE
Update band template to fix off-centered Contact section

### DIFF
--- a/templates/band.html
+++ b/templates/band.html
@@ -272,8 +272,8 @@
         </div>
     </section>
 
-    <section class="section columns">
-        <div class="container has-text-centered column is-10 is-offset-1">
+    <section class="section">
+        <div class="container has-text-centered">
             <h2 class="title">Contact</h2>
 
             <form>


### PR DESCRIPTION
The Contact section is off-centered at larger screen sizes. By removing the column classes the Contact section will be centered properly.